### PR TITLE
allow side-by-side comparison

### DIFF
--- a/demos/autumn-converted.html
+++ b/demos/autumn-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../autumn.css">
+<link type="text/css" rel="stylesheet" href="../autumn.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/autumn-original.html
+++ b/demos/autumn-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/autumn.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/autumn.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/colorful-converted.html
+++ b/demos/colorful-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../colorful.css">
+<link type="text/css" rel="stylesheet" href="../colorful.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/colorful-original.html
+++ b/demos/colorful-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/colorful.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/colorful.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/fruity-converted.html
+++ b/demos/fruity-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../fruity.css">
+<link type="text/css" rel="stylesheet" href="../fruity.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/fruity-original.html
+++ b/demos/fruity-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/fruity.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/fruity.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/monokai-converted.html
+++ b/demos/monokai-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../monokai.css">
+<link type="text/css" rel="stylesheet" href="../monokai.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/monokai-original.html
+++ b/demos/monokai-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/monokai.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/monokai.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/native-converted.html
+++ b/demos/native-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../native.css">
+<link type="text/css" rel="stylesheet" href="../native.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/native-original.html
+++ b/demos/native-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/native.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/native.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/perldoc-converted.html
+++ b/demos/perldoc-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../perldoc.css">
+<link type="text/css" rel="stylesheet" href="../perldoc.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/perldoc-original.html
+++ b/demos/perldoc-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/perldoc.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/perldoc.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/solarized-dark-converted.html
+++ b/demos/solarized-dark-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../solarized-dark.css">
+<link type="text/css" rel="stylesheet" href="../solarized-dark.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/solarized-dark-original.html
+++ b/demos/solarized-dark-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/solarized-dark.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/solarized-dark.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/solarized-light-converted.html
+++ b/demos/solarized-light-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../solarized-light.css">
+<link type="text/css" rel="stylesheet" href="../solarized-light.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/solarized-light-original.html
+++ b/demos/solarized-light-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/solarized-light.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/solarized-light.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/trac-converted.html
+++ b/demos/trac-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../trac.css">
+<link type="text/css" rel="stylesheet" href="../trac.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/trac-original.html
+++ b/demos/trac-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/trac.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/trac.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/vim-converted.html
+++ b/demos/vim-converted.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../vim.css">
+<link type="text/css" rel="stylesheet" href="../vim.css">
 <style>
 html, body {
   margin: 0;

--- a/demos/vim-original.html
+++ b/demos/vim-original.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../original-stylesheets/vim.css">
+<link type="text/css" rel="stylesheet" href="../original-stylesheets/vim.css">
 <style>
 html, body {
   margin: 0;

--- a/index.html
+++ b/index.html
@@ -1,25 +1,150 @@
+<!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
     <title>pygments-high-contrast-stylesheets</title>
     <meta name="description" content="A hard fork of pygments-css with WCAG AA passing stylesheets">
     <style>
-    iframe {
-      width: 600;
-      height: 450;
-      border: 0;
-      display: block;
-    }
+      iframe {
+        width: 600px;
+        height: 450px;
+        border: 0px;
+        display: inline;
+      }
+      td {
+        text-align: center;
+      }
+      table { border-collapse: collapse; }
+      .bordered {
+        padding-bottom: 2em;
+        border-top: 1px solid black;
+      }
     </style>
-</head>
-<body>
-<h1>pygments-high-contrast-stylesheets</h1>
-<p>A hard fork of <a href="https://github.com/richleland/pygments-css">pygments-css</a> with WCAG AA passing stylesheets.</p>
-<p><a href="https://github.com/mpchadwick/pygments-high-contrast-stylesheets">View Project on GitHub</a></p>
-<h2>Why?</h2>
-<p>When you're choosing a theme for your personal IDE feel free to choose whatever you'd like. But when you're publishing to the web, keep in mind that you're not the only one reading the code using the selected theme.</p>
-<p>These high contrast themes pass WCAG AA's standards, making them more friendly to the large segment of the population with color vision deficiency.</p>
-<h2>Demos</h2>
-<h3>autumn.css</h3><iframe src="demos/autumn-converted.html" title="autumn.css demo"></iframe><h3>colorful.css</h3><iframe src="demos/colorful-converted.html" title="colorful.css demo"></iframe><h3>fruity.css</h3><iframe src="demos/fruity-converted.html" title="fruity.css demo"></iframe><h3>monokai.css</h3><iframe src="demos/monokai-converted.html" title="monokai.css demo"></iframe><h3>native.css</h3><iframe src="demos/native-converted.html" title="native.css demo"></iframe><h3>perldoc.css</h3><iframe src="demos/perldoc-converted.html" title="perldoc.css demo"></iframe><h3>solarized-dark.css</h3><iframe src="demos/solarized-dark-converted.html" title="solarized-dark.css demo"></iframe><h3>solarized-light.css</h3><iframe src="demos/solarized-light-converted.html" title="solarized-light.css demo"></iframe><h3>trac.css</h3><iframe src="demos/trac-converted.html" title="trac.css demo"></iframe><h3>vim.css</h3><iframe src="demos/vim-converted.html" title="vim.css demo"></iframe>
-<p><a href="https://github.com/mpchadwick/pygments-high-contrast-stylesheets">View Project on GitHub</a></p>
-</body>
+  </head>
+  <body>
+    <h1>pygments-high-contrast-stylesheets</h1>
+
+    <p>A hard fork of <a href="https://github.com/richleland/pygments-css">pygments-css</a> with WCAG AA passing stylesheets.</p>
+
+    <p><a href="https://github.com/mpchadwick/pygments-high-contrast-stylesheets">View Project on GitHub</a></p>
+
+    <h2>Why?</h2>
+
+    <p>When you're choosing a theme for your personal IDE feel free to choose whatever you'd like. But when you're publishing to the web, keep in mind that you're not the only one reading the code using the selected theme.</p>
+
+    <p>These high contrast themes pass WCAG AA's standards, making them more friendly to the large segment of the population with color vision deficiency.</p>
+
+    <h2>Demos</h2>
+
+    <table style="width:100%">
+      <tr>
+        <td><a href="autumn.css">converted autumn.css</a></td>
+        <td><a href="original-stylesheets/autumn.css">original autumn.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/autumn-converted.html" title="autumn.css demo"></iframe></td>
+        <td><iframe src="demos/autumn-original.html" title="autumn.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="colorful.css">converted colorful.css</a></td>
+        <td><a href="original-stylesheets/colorful.css">original colorful.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/colorful-converted.html" title="colorful.css demo"></iframe></td>
+        <td><iframe src="demos/colorful-original.html" title="colorful.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="fruity.css">converted fruity.css</a></td>
+        <td><a href="original-stylesheets/fruity.css">original fruity.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/fruity-converted.html" title="fruity.css demo"></iframe></td>
+        <td><iframe src="demos/fruity-original.html" title="fruity.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="monokai.css">converted monokai.css</a></td>
+        <td><a href="original-stylesheets/monokai.css">original monokai.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/monokai-converted.html" title="monokai.css demo"></iframe></td>
+        <td><iframe src="demos/monokai-original.html" title="monokai.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="native.css">converted native.css</a></td>
+        <td><a href="original-stylesheets/native.css">original native.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/native-converted.html" title="native.css demo"></iframe></td>
+        <td><iframe src="demos/native-original.html" title="native.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="perldoc.css">converted perldoc.css</a></td>
+        <td><a href="original-stylesheets/perldoc.css">original perldoc.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/perldoc-converted.html" title="perldoc.css demo"></iframe></td>
+        <td><iframe src="demos/perldoc-original.html" title="perldoc.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="solarized-dark.css">converted solarized-dark.css</a></td>
+        <td><a href="original-stylesheets/solarized-dark.css">original solarized-dark.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/solarized-dark-converted.html" title="solarized-dark.css demo"></iframe></td>
+        <td><iframe src="demos/solarized-dark-original.html" title="solarized-dark.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="solarized-light.css">converted solarized-light.css</a></td>
+        <td><a href="original-stylesheets/solarized-light.css">original solarized-light.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/solarized-light-converted.html" title="solarized-light.css demo"></iframe></td>
+        <td><iframe src="demos/solarized-light-original.html" title="solarized-light.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="trac.css">converted trac.css</a></td>
+        <td><a href="original-stylesheets/trac.css">original trac.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/trac-converted.html" title="trac.css demo"></iframe></td>
+        <td><iframe src="demos/trac-original.html" title="trac.css original demo"></iframe></td>
+      </tr>
+      <!-- simulate horizontal rule -->
+      <tr><td class="bordered"></td><td class="bordered"></td></tr>
+      <!-- end horizontal rule -->
+      <tr>
+        <td><a href="vim.css">converted vim.css</a></td>
+        <td><a href="original-stylesheets/vim.css">original vim.css</a></td>
+      </tr>
+      <tr>
+        <td><iframe src="demos/vim-converted.html" title="vim.css demo"></iframe></td>
+        <td><iframe src="demos/vim-original.html" title="vim.css original demo"></iframe></td>
+      </tr>
+    </table>
+
+    <p><a href="https://github.com/mpchadwick/pygments-high-contrast-stylesheets">View Project on GitHub</a></p>
+  </body>
 </html>


### PR DESCRIPTION
Hi @mpchadwick!  I thought it would be nice to enable a side-by-side comparison of the converted / original stylesheets, so that's what this does :smile:

- add a table in index with some hacky borders
    - cannot border a `<tr>` unfortunately
- had to add `type="text/css"` to `individual demo-*` pages in order for them to load the correct CSS
    - without this, both table entries used the same CSS

I'm no expert at HTML, and this is definitely a **very** basic table.  But one tool you may find useful is the [W3 validator](https://validator.w3.org/nu/#textarea).  The `index.html` on this PR passes all checks.

Zoomed out screen: 

![pygments_high_contrast](https://user-images.githubusercontent.com/5871461/38866124-b6620030-41f4-11e8-8d41-e53995097fbb.jpeg)

**Note**: I don't know if this will all work when you bring GitHub pages into the mix, but don't see a reason why it wouldn't.  It's also worth mentioning that the hard-coded `iframe` `width` and `height` sizes in their current form probably mean that for mobile devices the table will be awkward.  But I don't know how to solve that with pure HTML / CSS.  Bootstrap is an easy thing to bring in here, but I don't have time to do it / don't know if it would work well with the rest of your site.

Anyway, I really respected that you took the time to improve these for people with color vision deficiencies. Though I myself have normal color vision, it's very important to be able to make websites compatible (man, look at the `vim` theme, soooo much better!).  Great work!!!

The side-by-side inclusion is my humble thank you :blush:
